### PR TITLE
Update theme.dart

### DIFF
--- a/lib/theme.dart
+++ b/lib/theme.dart
@@ -66,8 +66,10 @@ class AppTheme {
 
   /// Dark theme and its settings.
   ThemeData get dark => ThemeData(
-        brightness: Brightness.dark,
-        colorScheme: darkBase.colorScheme.copyWith(secondary: accentColor),
+        colorScheme: darkBase.colorScheme.copyWith(
+          secondary: accentColor, 
+          brightness: Brightness.dark,
+        ),
         visualDensity: visualDensity,
         textTheme:
             GoogleFonts.interTextTheme().apply(bodyColor: AppColors.textLigth),


### PR DESCRIPTION
I've used the `brightness: Brightness.dark` parameter for my dark mode without any problems until a recent flutter update (3.7.3). After the update, I'm getting this error:

> 'package:flutter/src/material/theme_data.dart': Failed assertion: line 412 pos 12: 'colorScheme?.brightness == null || brightness == null || colorScheme!.brightness == brightness': is not true.


This is a consequence of tightening up the ThemeData constructor the brightness parameter and the ColorScheme's brightness parameter in an update of Flutter. In this case,the brightness of the ColorScheme is light (the default), but the ThemeData's brightness is dark. So that, we need to remove the brightness parameter and put that in the colorScheme